### PR TITLE
Rails 3.1-compatible template handling

### DIFF
--- a/lib/erb_latex.rb
+++ b/lib/erb_latex.rb
@@ -5,6 +5,10 @@ require 'action_view'
 module ActionView               # :nodoc: all
   module Template::Handlers
     class ERBLatex < ERB
+      def self.call(template)
+        new.compile(template)
+      end
+      
       def compile(template)
         erb = "<% __in_erb_template=true %>#{template.source}"
         out=self.class.erb_implementation.new(erb, :trim=>(self.class.erb_trim_mode == "-")).src


### PR DESCRIPTION
Template API changed in Rails 3.1 to require the handler to imlement
a #call-method instead of -compile.

This change is still compatible with Rails 3.0.
