### PR TITLE
Support for linking with additional .cls and .sty files 

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -17,6 +17,11 @@ class LatexToPdf
     dir=File.join(Rails.root,'tmp','rails-latex',"#{Process.pid}-#{Thread.current.hash}")
     input=File.join(dir,'input.tex')
     FileUtils.mkdir_p(dir)
+    # copy any additional supporting files (.cls, .sty, ...)
+    supporting = config[:supporting]
+    if supporting.class == String or supporting.class == Array and supporting.length > 0
+      FileUtils.cp(supporting, dir)
+    end
     File.open(input,'wb') {|io| io.write(code) }
     Process.waitpid(
       fork do


### PR DESCRIPTION
Sometimes you have a complex TeX template that links with external .sty and .cls files.
With this merge, user can place such files in his app root and list them in config:
LatexToPdf.config[:supporting] = %w(res.cls helvetica.sty)
and rails-latex will copy them in the same directory of input.tex
Here is an example:
https://github.com/hammady/myresume
