### PR TITLE
Accept Pathnames and directories as supporting files.

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -19,8 +19,8 @@ class LatexToPdf
     FileUtils.mkdir_p(dir)
     # copy any additional supporting files (.cls, .sty, ...)
     supporting = config[:supporting]
-    if supporting.class == String or supporting.class == Array and supporting.length > 0
-      FileUtils.cp(supporting, dir)
+    if supporting.kind_of?(String) or supporting.kind_of?(Pathname) or (supporting.kind_of?(Array) and supporting.length > 0)
+      FileUtils.cp_r(supporting, dir)
     end
     File.open(input,'wb') {|io| io.write(code) }
     Process.waitpid(


### PR DESCRIPTION
- Accept Pathnames so that you can write something like:
  
  ``` ruby
  LatexToPdf.config.merge!({
    supporting: Rails.root.join("latex.cls") # Rails.root is a Pathname.
  })
  ```
- Do a recursive copy so that you can copy in directories.  In my case, I had a `fonts` directory that I wanted to reference.
- Use `kind_of?` instead of `class ==` to match subclasses.
