### PR TITLE
add encoding to latex_to_pdf to solve invalid ASCII errors for ruby 1.9

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 class LatexToPdf
   def self.config
     @config||={:command => 'pdflatex', :arguments => ['-halt-on-error'], :parse_twice => false, :parse_runs => 1}


### PR DESCRIPTION
PDF generation failed while calling LatexToPdf.escape_latex whenever there are accented characters. Added coding: utf-8 to top of this file to solve this issue for ruby 1.9
