### PR TITLE
redirect latex output to file

### DIFF
--- a/examples/rails-latex-demo/Gemfile.lock
+++ b/examples/rails-latex-demo/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ../../
   specs:
-    rails-latex (1.0.11)
+    rails-latex (1.0.14)
       rails (>= 3.0.0)
 
 GEM

--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -16,7 +16,7 @@ class LatexToPdf
     config=self.config.merge(config)
     parse_twice=config[:parse_twice] if parse_twice.nil? # deprecated
     parse_runs=[config[:parse_runs], (parse_twice ? 2 : config[:parse_runs])].max
-    puts "Running Latex #{parse_runs} times..."
+    # puts "Running Latex #{parse_runs} times..."
     dir=File.join(Rails.root,'tmp','rails-latex',"#{Process.pid}-#{Thread.current.hash}")
     input=File.join(dir,'input.tex')
     FileUtils.mkdir_p(dir)
@@ -30,19 +30,19 @@ class LatexToPdf
       fork do
         begin
           Dir.chdir dir
-          original_stdout, original_stderr = $stdout, $stderr
-          $stderr = $stdout = File.open("input.log","a")
+          # original_stdout, original_stderr = $stdout, $stderr
+          # $stderr = $stdout = File.open("input.log","a")
           args=config[:arguments] + %w[-shell-escape -interaction batchmode input.tex]
           (parse_runs-1).times do
-            system config[:command],'-draftmode',*args
+            system config[:command],'-draftmode',*args, [:out,:err] => ['input.log', 'a']
           end
-          exec config[:command],*args
+          exec config[:command],*args, [:out,:err] => ['input.log', 'a']
         rescue
           File.open("input.log",'a') {|io|
             io.write("#{$!.message}:\n#{$!.backtrace.join("\n")}\n")
           }
         ensure
-          $stdout, $stderr = original_stdout, original_stderr
+          # $stdout, $stderr = original_stdout, original_stderr
           Process.exit! 1
         end
       end)

--- a/lib/rails-latex/version.rb
+++ b/lib/rails-latex/version.rb
@@ -1,5 +1,5 @@
 module Rails
   module Latex
-    VERSION = "1.0.13"
+    VERSION = "1.0.14"
   end
 end


### PR DESCRIPTION
In 1.0.13 the output from the latex process isn't redirected to file. This change corrects this issue, and redirects the system call stdout and stderr to the input.log file.

It would be great if you could merge this request and push a new version of the gem.

cheers, Andrew