### PR TITLE
Suppress STDOUT

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -16,7 +16,7 @@ class LatexToPdf
     config=self.config.merge(config)
     parse_twice=config[:parse_twice] if parse_twice.nil? # deprecated
     parse_runs=[config[:parse_runs], (parse_twice ? 2 : config[:parse_runs])].max
-    puts "Running Latex #{parse_runs} times..."
+    Rails.logger.info "Running Latex #{parse_runs} times..."
     dir=File.join(Rails.root,'tmp','rails-latex',"#{Process.pid}-#{Thread.current.hash}")
     input=File.join(dir,'input.tex')
     FileUtils.mkdir_p(dir)
@@ -30,19 +30,17 @@ class LatexToPdf
       fork do
         begin
           Dir.chdir dir
-          original_stdout, original_stderr = $stdout, $stderr
-          $stderr = $stdout = File.open("input.log","a")
           args=config[:arguments] + %w[-shell-escape -interaction batchmode input.tex]
+          kwargs={:out => ["input.log","a"]}
           (parse_runs-1).times do
-            system config[:command],'-draftmode',*args
+            system config[:command],'-draftmode',*args,**kwargs
           end
-          exec config[:command],*args
+          exec config[:command],*args,**kwargs
         rescue
           File.open("input.log",'a') {|io|
             io.write("#{$!.message}:\n#{$!.backtrace.join("\n")}\n")
           }
         ensure
-          $stdout, $stderr = original_stdout, original_stderr
           Process.exit! 1
         end
       end)

--- a/test/test_latex_to_pdf.rb
+++ b/test/test_latex_to_pdf.rb
@@ -4,7 +4,7 @@ require 'rails-latex/erb_latex'
 require 'ostruct'
 require 'pathname'
 
-Rails=OpenStruct.new(:root => TMP_DIR=File.expand_path("../tmp",__FILE__))
+Rails=OpenStruct.new(:root => TMP_DIR=File.expand_path("../tmp",__FILE__), :logger => Logger.new(STDERR))
 
 class TestLatexToPdf < Test::Unit::TestCase
   def setup


### PR DESCRIPTION
This gem is really useful - using it a lot on a current project!

I've been getting a lot of STDOUT messages, e.g., when running RSpec:

    $ rspec spec/requests/pdf_spec.rb
    Running Latex 2 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    Running Latex 2 times...
    [etc etc...]

The changes I've made redirect the "Running Latex n times..." message to the Rails logger (info), and the "This is pdfTeX..." messages to `input.log`.

Tested only on Ruby 2.2.2.

**Output from `rake test`**

Before:

    $ rake test
    /Users/anthonys/.rbenv/versions/2.2.2/bin/ruby -I"lib:lib:test"  "/Users/anthonys/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/test_*.rb" 
    Loaded suite /Users/anthonys/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader
    Started
    Running Latex 1 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    .Running Latex 1 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    .Running Latex 1 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    ..Running Latex 1 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    .Running Latex 2 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    .Running Latex 2 times...
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    This is pdfTeX, Version 3.14159265-2.6-1.40.15 (TeX Live 2014) (preloaded format=pdflatex)
     \write18 enabled.
    entering extended mode
    .

    Finished in 11.782673 seconds.

    7 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

    0.59 tests/s, 1.02 assertions/s

After:

    $ rake test
    /Users/anthonys/.rbenv/versions/2.2.2/bin/ruby -I"lib:lib:test"  "/Users/anthonys/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/**/test_*.rb" 
    Loaded suite /Users/anthonys/.rbenv/versions/2.2.2/lib/ruby/2.2.0/rake/rake_test_loader
    Started
    I, [2015-08-19T13:03:03.167352 #93003]  INFO -- : Running Latex 1 times...
    .I, [2015-08-19T13:03:04.443874 #93003]  INFO -- : Running Latex 1 times...
    .I, [2015-08-19T13:03:05.946938 #93003]  INFO -- : Running Latex 1 times...
    ..I, [2015-08-19T13:03:07.647789 #93003]  INFO -- : Running Latex 1 times...
    .I, [2015-08-19T13:03:09.117118 #93003]  INFO -- : Running Latex 2 times...
    .I, [2015-08-19T13:03:12.266944 #93003]  INFO -- : Running Latex 2 times...
    .

    Finished in 12.296752 seconds.

    7 tests, 12 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
    100% passed

    0.57 tests/s, 0.98 assertions/s

**Output from `rspec` after changes**

    $ rspec spec/requests/pdf_spec.rb
    ......

    Finished in 1 minute 3.33 seconds (files took 12.1 seconds to load)
    6 examples, 0 failures
