### PR TITLE
FIX: Ensure gem works with rails 3 and 4

### DIFF
--- a/lib/rails-latex/version.rb
+++ b/lib/rails-latex/version.rb
@@ -1,3 +1,3 @@
 module RailsLatex
-  VERSION = "2.0.0"
+  VERSION = "2.0.1"
 end

--- a/rails-latex.gemspec
+++ b/rails-latex.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", "~> 3.0"
+  spec.add_runtime_dependency 'rails', '>= 3.0.0', '< 5'
   spec.add_development_dependency "RedCloth", "~> 4.2"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
I've been using this gem with Rails 4, but the dependencies for version 2.0.0 explicitly require version 3, and as a result, the dependency stops the gem being installed in Rails 4.

This change ensures the dependency allows the gem to work with both Rails 3 and 4.