### PR TITLE
Don't call `gsub` on a `SafeBuffer`.

### DIFF
--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -138,6 +138,6 @@ class LatexToPdf
       # :startdoc:
     end
 
-    @latex_escaper.latex_esc(text.to_s).html_safe
+    @latex_escaper.latex_esc(text.to_s.to_str).html_safe
   end
 end


### PR DESCRIPTION
SafeBuffer#gsub doesn't set backreferences ($1, $2, etc...) correctly
due to https://github.com/rails/rails/issues/1555 .  Avoid that by
converting the SafeBuffer to a String using `to_str` (not `to_s`, which
returns another SafeBuffer).