### PR TITLE
Fix/add support for rails 6

### DIFF
--- a/examples/rails-latex-demo/config/environments/production.rb
+++ b/examples/rails-latex-demo/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
-  config.i18n.fallbacks = true
+  config.i18n.fallbacks = [I18n.default_locale]
 
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify

--- a/lib/rails-latex/erb_latex.rb
+++ b/lib/rails-latex/erb_latex.rb
@@ -6,12 +6,13 @@ require 'action_view'
 module ActionView               # :nodoc: all
   module Template::Handlers
     class ERBLatex < ERB
-      def self.call(template)
-        new.compile(template)
+      def self.call(template, source = nil)
+        source ||= template.source
+        new.compile(template, source)
       end
 
-      def compile(template)
-        erb = "<% __in_erb_template=true %>#{template.source}"
+      def compile(template, source)
+        erb = "<% __in_erb_template=true %>#{source}"
         out=self.class.erb_implementation.new(erb, :trim=>(self.class.erb_trim_mode == "-")).src
         out + ";LatexToPdf.generate_pdf(@output_buffer.to_s, @latex_config||{})"
       end

--- a/lib/rails-latex/latex_to_pdf.rb
+++ b/lib/rails-latex/latex_to_pdf.rb
@@ -107,7 +107,7 @@ class LatexToPdf
   # This method will use RedCloth to do the escaping if available.
   def self.escape_latex(text)
     # :stopdoc:
-    unless @latex_escaper
+    unless instance_variable_defined?(:@latex_escaper) && @latex_escaper
       if defined?(RedCloth::Formatters::LATEX)
         class << (@latex_escaper=RedCloth.new(''))
           include RedCloth::Formatters::LATEX

--- a/lib/rails-latex/version.rb
+++ b/lib/rails-latex/version.rb
@@ -1,3 +1,3 @@
 module RailsLatex
-  VERSION = "2.3.2"
+  VERSION = "2.3.3"
 end

--- a/rails-latex.gemspec
+++ b/rails-latex.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency 'rails', '>= 3.0.0', '< 6'
+  spec.add_runtime_dependency 'rails', '>= 3.0.0', '< 7'
   spec.add_development_dependency "RedCloth", "~> 4.3"
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 12.3"


### PR DESCRIPTION
This PR updates the template structure to work with rails 6. All tests pass, once #59 is merged.

Includes some small changes to address issues raised:

- i18n changes to switch to default locale fallback
- Existence checking of `latex_escaper` to use `instance_variable_defined?(:@latex_escaper)` to remove warnings

Also includes minor version bump to 2.3.3